### PR TITLE
Add Telegram chat workspace and admin pagination

### DIFF
--- a/src/__tests__/admin-callback.test.ts
+++ b/src/__tests__/admin-callback.test.ts
@@ -1,50 +1,25 @@
 import type { NextRequest } from 'next/server'
 
-const ADMIN_SESSION_COOKIE = 'telegram_admin_session'
-const OIDC_NONCE_COOKIE = 'telegram_admin_oidc_nonce'
-const OIDC_STATE_COOKIE = 'telegram_admin_oidc_state'
-const OIDC_VERIFIER_COOKIE = 'telegram_admin_oidc_verifier'
+jest.mock('server-only', () => ({}))
 
-const createAdminSessionMock = jest.fn()
-const fetchMock = jest.fn()
-const getTelegramOidcConfigurationMock = jest.fn(() => ({
-  clientId: '123456789',
-  clientSecret: 'telegram-client-secret',
-  redirectUri: 'https://telegram-bot-ui.vercel.app/admin/callback',
-}))
-const originalFetch = globalThis.fetch
-globalThis.fetch = fetchMock as typeof fetch
-
-class MockAdminApiError extends Error {
-  constructor(
-    message: string,
-    readonly status: number,
-  ) {
-    super(message)
-  }
-}
-
-jest.mock('@/lib/admin-api', () => ({
-  AdminApiError: MockAdminApiError,
-  createAdminSession: createAdminSessionMock,
-}))
-
-jest.mock('@/lib/admin-config', () => ({
-  getTelegramOidcConfiguration: getTelegramOidcConfigurationMock,
-}))
-
-jest.mock('@/lib/admin-session', () => ({
-  ADMIN_SESSION_COOKIE,
+const adminApi = await import('@/lib/admin-api')
+const adminConfig = await import('@/lib/admin-config')
+const {
+  OIDC_BACK_URL_COOKIE,
   OIDC_NONCE_COOKIE,
   OIDC_STATE_COOKIE,
   OIDC_VERIFIER_COOKIE,
-  adminCookieOptions: {
-    httpOnly: true,
-    sameSite: 'lax',
-    secure: true,
-    path: '/admin',
-  },
-}))
+  SESSION_COOKIE,
+} = await import('@/lib/admin-session')
+
+const createSessionMock = jest.spyOn(adminApi, 'createSession')
+const fetchMock = jest.fn()
+const getTelegramOidcConfigurationMock = jest.spyOn(
+  adminConfig,
+  'getTelegramOidcConfiguration',
+)
+const originalFetch = globalThis.fetch
+globalThis.fetch = fetchMock as typeof fetch
 
 const { GET } = await import('../app/admin/callback/route')
 
@@ -66,57 +41,72 @@ function callbackRequest(
 }
 
 describe('Telegram OIDC callback', () => {
+  beforeEach(() => {
+    getTelegramOidcConfigurationMock.mockReturnValue({
+      clientId: '123456789',
+      clientSecret: 'telegram-client-secret',
+      redirectUri: 'https://telegram-bot-ui.vercel.app/admin/callback',
+    })
+  })
+
   afterEach(() => {
-    createAdminSessionMock.mockReset()
+    createSessionMock.mockReset()
     fetchMock.mockReset()
     getTelegramOidcConfigurationMock.mockClear()
   })
 
   afterAll(() => {
     globalThis.fetch = originalFetch
+    createSessionMock.mockRestore()
+    getTelegramOidcConfigurationMock.mockRestore()
   })
 
-  test('rejects invalid callback state before making external requests', async () => {
+  test('rejects invalid state before requests and preserves a safe back URL', async () => {
     const response = await GET(
       callbackRequest('?code=code&state=wrong', {
         [OIDC_STATE_COOKIE]: 'expected',
         [OIDC_NONCE_COOKIE]: 'nonce',
         [OIDC_VERIFIER_COOKIE]: 'verifier',
+        [OIDC_BACK_URL_COOKIE]: '/chat/-1001',
       }),
     )
 
     expect(response.headers.get('location')).toBe(
-      'https://telegram-bot-ui.vercel.app/admin/sign-in?error=invalid_state',
+      'https://telegram-bot-ui.vercel.app/sign-in?error=invalid_state&backUrl=%2Fchat%2F-1001',
     )
     expect(fetchMock).not.toHaveBeenCalled()
-    expect(createAdminSessionMock).not.toHaveBeenCalled()
+    expect(createSessionMock).not.toHaveBeenCalled()
     expect(
       response.cookies
         .getAll()
         .filter(({ name }) =>
-          [OIDC_STATE_COOKIE, OIDC_NONCE_COOKIE, OIDC_VERIFIER_COOKIE].includes(
-            name,
-          ),
+          [
+            OIDC_STATE_COOKIE,
+            OIDC_NONCE_COOKIE,
+            OIDC_VERIFIER_COOKIE,
+            OIDC_BACK_URL_COOKIE,
+          ].includes(name),
         )
         .map(({ name, value }) => ({ name, value })),
     ).toEqual([
       { name: OIDC_STATE_COOKIE, value: '' },
       { name: OIDC_NONCE_COOKIE, value: '' },
       { name: OIDC_VERIFIER_COOKIE, value: '' },
+      { name: OIDC_BACK_URL_COOKIE, value: '' },
     ])
   })
 
-  test('exchanges a valid code and replaces OIDC cookies with an admin session', async () => {
+  test('exchanges PKCE code, creates a shared session, and returns to the chat', async () => {
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ id_token: 'telegram-id-token' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }),
     )
-    createAdminSessionMock.mockResolvedValue({
-      token: 'admin-session-token',
+    createSessionMock.mockResolvedValue({
+      token: 'session-token',
       expiresIn: 43_200,
-      admin: { id: '42' },
+      user: { id: '42', isAdmin: true },
     })
 
     const response = await GET(
@@ -124,27 +114,44 @@ describe('Telegram OIDC callback', () => {
         [OIDC_STATE_COOKIE]: 'expected',
         [OIDC_NONCE_COOKIE]: 'nonce',
         [OIDC_VERIFIER_COOKIE]: 'verifier',
+        [OIDC_BACK_URL_COOKIE]: '/chat/-1001',
       }),
     )
 
     expect(response.headers.get('location')).toBe(
-      'https://telegram-bot-ui.vercel.app/admin',
+      'https://telegram-bot-ui.vercel.app/chat/-1001',
     )
-    expect(fetchMock).toHaveBeenCalledTimes(1)
     const [, init] = fetchMock.mock.calls[0]
-    expect(init?.method).toBe('POST')
     expect(new URLSearchParams(String(init?.body)).get('code_verifier')).toBe(
       'verifier',
     )
-    expect(createAdminSessionMock).toHaveBeenCalledWith(
-      'telegram-id-token',
-      'nonce',
+    expect(createSessionMock).toHaveBeenCalledWith('telegram-id-token', 'nonce')
+    expect(response.cookies.get(SESSION_COOKIE)?.value).toBe('session-token')
+  })
+
+  test('never redirects to an external back URL', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ id_token: 'telegram-id-token' }), {
+        status: 200,
+      }),
     )
-    expect(response.cookies.get(ADMIN_SESSION_COOKIE)?.value).toBe(
-      'admin-session-token',
+    createSessionMock.mockResolvedValue({
+      token: 'session-token',
+      expiresIn: 43_200,
+      user: { id: '7', isAdmin: false },
+    })
+
+    const response = await GET(
+      callbackRequest('?code=authorization-code&state=expected', {
+        [OIDC_STATE_COOKIE]: 'expected',
+        [OIDC_NONCE_COOKIE]: 'nonce',
+        [OIDC_VERIFIER_COOKIE]: 'verifier',
+        [OIDC_BACK_URL_COOKIE]: '//evil.example/steal',
+      }),
     )
-    expect(response.cookies.get(OIDC_STATE_COOKIE)?.value).toBe('')
-    expect(response.cookies.get(OIDC_NONCE_COOKIE)?.value).toBe('')
-    expect(response.cookies.get(OIDC_VERIFIER_COOKIE)?.value).toBe('')
+
+    expect(response.headers.get('location')).toBe(
+      'https://telegram-bot-ui.vercel.app/',
+    )
   })
 })

--- a/src/__tests__/admin-dashboard.test.tsx
+++ b/src/__tests__/admin-dashboard.test.tsx
@@ -62,14 +62,16 @@ describe('admin dashboard', () => {
 
   test('debounces search into the server-backed URL query', async () => {
     jest.useFakeTimers()
-    render(<AdminDashboard initialData={initialData} updateChat={jest.fn()} />)
-
-    fireEvent.change(
-      screen.getByRole('searchbox', {
-        name: /search chats by name, username or id/i,
-      }),
-      { target: { value: '@alpha_chat' } },
+    const updateChat = jest.fn()
+    const { rerender } = render(
+      <AdminDashboard initialData={initialData} updateChat={updateChat} />,
     )
+
+    const searchInput = screen.getByRole('searchbox', {
+      name: /search chats by name, username or id/i,
+    })
+    searchInput.focus()
+    fireEvent.change(searchInput, { target: { value: '@alpha_chat' } })
     expect(replaceMock).not.toHaveBeenCalled()
 
     await act(async () => {
@@ -77,6 +79,22 @@ describe('admin dashboard', () => {
     })
 
     expect(replaceMock).toHaveBeenCalledWith('/admin?q=%40alpha_chat')
+    fireEvent.change(searchInput, {
+      target: { value: '@alpha_chat newest text' },
+    })
+    rerender(
+      <AdminDashboard
+        initialData={{
+          ...initialData,
+          query: { ...initialData.query, q: '@alpha_chat' },
+        }}
+        updateChat={updateChat}
+      />,
+    )
+
+    expect(searchInput).toHaveFocus()
+    expect(searchInput).toHaveValue('@alpha_chat newest text')
+    jest.clearAllTimers()
     jest.useRealTimers()
   })
 

--- a/src/__tests__/admin-dashboard.test.tsx
+++ b/src/__tests__/admin-dashboard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import type {
   AdminChatPatch,
@@ -7,9 +7,12 @@ import type {
 } from '@/lib/admin-types'
 
 const refreshMock = jest.fn()
+const replaceMock = jest.fn()
 
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ refresh: refreshMock }),
+  usePathname: () => '/admin',
+  useRouter: () => ({ refresh: refreshMock, replace: replaceMock }),
+  useSearchParams: () => new URLSearchParams(),
 }))
 
 const { AdminDashboard } = await import('../app/admin/admin-dashboard')
@@ -39,20 +42,27 @@ const initialData: AdminChatsResponse = {
       lastActivityAt: 1_000,
     },
   ],
+  pagination: { page: 1, pageSize: 20, total: 2, totalPages: 1 },
+  summary: { total: 2, allowed: 1, enabled: 1 },
+  query: {
+    page: 1,
+    pageSize: 20,
+    q: '',
+    aiAccess: 'all',
+    sort: 'lastActivityAt',
+    direction: 'desc',
+  },
 }
 
 describe('admin dashboard', () => {
   beforeEach(() => {
     refreshMock.mockReset()
+    replaceMock.mockReset()
   })
 
-  test('searches chats by username and ID', async () => {
-    render(
-      <AdminDashboard
-        initialData={initialData}
-        updateChat={jest.fn()}
-      />,
-    )
+  test('debounces search into the server-backed URL query', async () => {
+    jest.useFakeTimers()
+    render(<AdminDashboard initialData={initialData} updateChat={jest.fn()} />)
 
     fireEvent.change(
       screen.getByRole('searchbox', {
@@ -60,23 +70,39 @@ describe('admin dashboard', () => {
       }),
       { target: { value: '@alpha_chat' } },
     )
+    expect(replaceMock).not.toHaveBeenCalled()
 
-    await waitFor(() => {
-      expect(screen.getByText('Alpha room')).toBeInTheDocument()
-      expect(screen.queryByText('Beta room')).not.toBeInTheDocument()
+    await act(async () => {
+      jest.advanceTimersByTime(300)
     })
+
+    expect(replaceMock).toHaveBeenCalledWith('/admin?q=%40alpha_chat')
+    jest.useRealTimers()
+  })
+
+  test('sends AI filters, sortable columns, and pagination to the URL', () => {
+    const pagedData: AdminChatsResponse = {
+      ...initialData,
+      pagination: { page: 1, pageSize: 20, total: 30, totalPages: 2 },
+      summary: { ...initialData.summary, total: 30 },
+    }
+    render(<AdminDashboard initialData={pagedData} updateChat={jest.fn()} />)
 
     fireEvent.change(
-      screen.getByRole('searchbox', {
-        name: /search chats by name, username or id/i,
-      }),
-      { target: { value: '-1002' } },
+      screen.getByRole('combobox', { name: 'Filter AI access' }),
+      {
+        target: { value: 'allowed' },
+      },
+    )
+    expect(replaceMock).toHaveBeenLastCalledWith('/admin?aiAccess=allowed')
+
+    fireEvent.click(screen.getByRole('button', { name: /^chat$/i }))
+    expect(replaceMock).toHaveBeenLastCalledWith(
+      '/admin?sort=name&direction=asc',
     )
 
-    await waitFor(() => {
-      expect(screen.getByText('Beta room')).toBeInTheDocument()
-      expect(screen.queryByText('Alpha room')).not.toBeInTheDocument()
-    })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    expect(replaceMock).toHaveBeenLastCalledWith('/admin?page=2')
   })
 
   test('sends an explicit versioned allowlist update', async () => {
@@ -91,9 +117,7 @@ describe('admin dashboard', () => {
         },
       }),
     )
-    render(
-      <AdminDashboard initialData={initialData} updateChat={updateChat} />,
-    )
+    render(<AdminDashboard initialData={initialData} updateChat={updateChat} />)
 
     fireEvent.click(
       screen.getByRole('switch', { name: 'Allow AI for Alpha room' }),
@@ -108,48 +132,34 @@ describe('admin dashboard', () => {
       expect(
         screen.getByRole('switch', { name: 'Disallow AI for Alpha room' }),
       ).toBeChecked()
+      expect(refreshMock).toHaveBeenCalledTimes(1)
     })
   })
 
-  test('refreshes and adopts server state after a conflicting update', async () => {
-    const updateChat = jest.fn(
-      async (): Promise<AdminChatUpdateResult> => ({
+  test('refreshes only after a conflicting failed update', async () => {
+    const updateChat = jest
+      .fn()
+      .mockResolvedValueOnce({
         ok: false,
-        error: 'Chat configuration changed. Refresh and try again.',
-      }),
-    )
-    const { rerender } = render(
-      <AdminDashboard initialData={initialData} updateChat={updateChat} />,
-    )
+        error: 'Validation failed.',
+      } satisfies AdminChatUpdateResult)
+      .mockResolvedValueOnce({
+        ok: false,
+        error: 'Chat configuration changed.',
+        conflict: true,
+      } satisfies AdminChatUpdateResult)
+    render(<AdminDashboard initialData={initialData} updateChat={updateChat} />)
 
     fireEvent.click(
       screen.getByRole('switch', { name: 'Allow AI for Alpha room' }),
     )
+    await screen.findByText('Validation failed.')
+    expect(refreshMock).not.toHaveBeenCalled()
 
-    await waitFor(() => {
-      expect(refreshMock).toHaveBeenCalledTimes(1)
-      expect(
-        screen.getByText('Chat configuration changed. Refresh and try again.'),
-      ).toBeInTheDocument()
-    })
-
-    const refreshedData: AdminChatsResponse = {
-      ...initialData,
-      chats: initialData.chats.map((chat) =>
-        chat.chatId === '-1001'
-          ? { ...chat, aiAllowed: true, version: 3 }
-          : chat,
-      ),
-    }
-    rerender(
-      <AdminDashboard initialData={refreshedData} updateChat={updateChat} />,
+    fireEvent.click(
+      screen.getByRole('switch', { name: 'Allow AI for Alpha room' }),
     )
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole('switch', { name: 'Disallow AI for Alpha room' }),
-      ).toBeChecked()
-      expect(screen.getByText('Config v3')).toBeInTheDocument()
-    })
+    await screen.findByText('Chat configuration changed.')
+    expect(refreshMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/__tests__/admin-session.test.ts
+++ b/src/__tests__/admin-session.test.ts
@@ -1,0 +1,17 @@
+jest.mock('server-only', () => ({}))
+
+export {}
+
+const { getSafeBackUrl } = await import('@/lib/admin-session')
+
+describe('safe login return URLs', () => {
+  test.each([
+    ['https://evil.example', '/'],
+    ['//evil.example', '/'],
+    ['/\\evil.example', '/'],
+    ['/chat/-1\r\nLocation: https://evil.example', '/'],
+    ['/chat/-1001?tab=day', '/chat/-1001?tab=day'],
+  ])('normalizes %p to %p', (value, expected) => {
+    expect(getSafeBackUrl(value)).toBe(expected)
+  })
+})

--- a/src/__tests__/chat-page.test.tsx
+++ b/src/__tests__/chat-page.test.tsx
@@ -1,10 +1,12 @@
-import React from 'react'
-import { render, screen, waitFor, act } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
-import ChatPage from '../app/chat/[id]/page'
 import { ThemeProvider } from '../contexts'
-
 import * as hooks from '../hooks/use-chat-data.hook'
+
+jest.mock('server-only', () => ({}))
+
+const { ChatDashboard } = await import('../app/chat/[id]/chat-dashboard')
+const { ChatAccessMessage } = await import('../app/chat/[id]/page')
 
 const useChatDataMock = jest.spyOn(hooks, 'useChatData')
 
@@ -17,99 +19,46 @@ afterAll(() => {
 })
 
 describe('Chat Page', () => {
-  it('shows the correct children and calls useChatData with correct arguments', async () => {
+  test('renders statistics with the resolved access token', async () => {
     useChatDataMock.mockReturnValue({
       data: {
         usersData: [
           { id: 1, username: 'user1', messages: 62, is_bot: false },
           { id: 2, username: 'user2', messages: 52, is_bot: false },
-          { id: 3, username: 'user3', messages: 30, is_bot: false },
-          { id: 4, username: 'user4', messages: 27, is_bot: false },
-          { id: 5, username: 'user5', messages: 16, is_bot: false },
-          { id: 6, username: 'user6', messages: 10, is_bot: false },
-          { id: 7, username: 'user7', messages: 9, is_bot: false },
-          { id: 8, username: 'user8', messages: 5, is_bot: false },
-          { id: 9, username: 'user9', messages: 3, is_bot: false },
         ],
       },
       loading: false,
       error: '',
     })
 
-    const params = Promise.resolve({ id: 'test-chat-id' })
-    const searchParams = Promise.resolve({ access: 'test-access-token' })
-
-    await act(async () => {
-      render(
-        <ThemeProvider>
-          <ChatPage params={params} searchParams={searchParams} />
-        </ThemeProvider>,
-      )
-      // Important: let the suspended promise settle INSIDE act
-      await params
-      await searchParams
-    })
-
-    expect(hooks.useChatData).toHaveBeenCalledWith(
-      'test-chat-id',
-      'test-access-token',
+    render(
+      <ThemeProvider>
+        <ChatDashboard chatId="-1001" accessToken="short-lived-token" />
+      </ThemeProvider>,
     )
 
-    // Use find* to wait for the post-suspense UI
+    expect(hooks.useChatData).toHaveBeenCalledWith('-1001', 'short-lived-token')
     expect(await screen.findAllByText('Barchart')).toHaveLength(2)
     expect(await screen.findByText('Piechart')).toBeInTheDocument()
   })
 
-  it('shows spinner while loading', async () => {
-    useChatDataMock.mockReturnValue({
-      data: { usersData: [] },
-      loading: true,
-      error: '',
-    })
+  test('shows a Telegram login that returns to the requested chat', () => {
+    render(<ChatAccessMessage chatId="-1001306676509" />)
 
-    const params = Promise.resolve({ id: 'test-chat-id' })
-    const searchParams = Promise.resolve({ access: 'test-access-token' })
-
-    await act(async () => {
-      render(
-        <ThemeProvider>
-          <ChatPage params={params} searchParams={searchParams} />
-        </ThemeProvider>,
-      )
-      await params
-      await searchParams
-    })
-
-    // Wait for the loading UI
-    expect(await screen.findAllByLabelText('spinner')).toHaveLength(2)
-
-    // While loading, charts should not be there; use waitFor with a negative assertion
-    await waitFor(() => {
-      expect(screen.queryAllByText('Barchart')).toHaveLength(0)
-      expect(screen.queryByText('Piechart')).not.toBeInTheDocument()
-    })
+    expect(screen.getByText('Sign in to continue.')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Continue with Telegram' }),
+    ).toHaveAttribute('href', '/login?backUrl=%2Fchat%2F-1001306676509')
   })
 
-  it('shows error if useChatData fails', async () => {
-    useChatDataMock.mockReturnValue({
-      data: { usersData: [] },
-      loading: false,
-      error: 'Something Went Wrong',
-    })
+  test('shows a clear denial for a chat outside the user list', () => {
+    render(<ChatAccessMessage chatId="-1001" denied />)
 
-    const params = Promise.resolve({ id: 'test-chat-id' })
-    const searchParams = Promise.resolve({ access: 'test-access-token' })
-
-    await act(async () => {
-      render(
-        <ThemeProvider>
-          <ChatPage params={params} searchParams={searchParams} />
-        </ThemeProvider>,
-      )
-      await params
-      await searchParams
-    })
-
-    expect(await screen.findByText('Something Went Wrong')).toBeInTheDocument()
+    expect(
+      screen.getByText('This chat is not in your list.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'View your chats' }),
+    ).toHaveAttribute('href', '/')
   })
 })

--- a/src/__tests__/index-page.test.tsx
+++ b/src/__tests__/index-page.test.tsx
@@ -1,29 +1,47 @@
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 
-import Index from '../app/page'
-import { ThemeProvider } from '@/contexts'
+jest.mock('server-only', () => ({}))
+
+const { SignedOutHome, UserHome } = await import('../app/page')
 
 describe('Index Page', () => {
-  beforeEach(() => {
-    render(
-      <ThemeProvider>
-        <Index />
-      </ThemeProvider>,
-    )
-  })
+  test('offers Telegram login without exposing public chat search', () => {
+    render(<SignedOutHome />)
 
-  it('shows the correct text', () => {
     expect(
-      screen.queryByText("Hi, I'm a Telegram chat bot."),
+      screen.getByText('Your chats, without public links.'),
     ).toBeInTheDocument()
     expect(
-      screen.queryByText(/Add the bot to your chat/i),
-    ).toBeInTheDocument()
-  })
-
-  it('does not expose public chat search', () => {
+      screen.getByRole('link', { name: 'Continue with Telegram' }),
+    ).toHaveAttribute('href', '/login?backUrl=%2F')
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
-    expect(screen.getByText(/private statistics link/i)).toBeInTheDocument()
+  })
+
+  test('shows only the signed-in user chat list and owner controls', () => {
+    render(
+      <UserHome
+        data={{
+          user: { id: '42', name: 'Owner', isAdmin: true },
+          chats: [
+            {
+              chatId: '-1001',
+              name: 'Alpha room',
+              type: 'supergroup',
+              lastActivityAt: 2_000,
+              messageCount: 12,
+            },
+          ],
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('link', { name: /Alpha room/ })).toHaveAttribute(
+      'href',
+      '/chat/-1001',
+    )
+    expect(screen.getByRole('link', { name: 'Control room' })).toHaveAttribute(
+      'href',
+      '/admin',
+    )
   })
 })

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -3,18 +3,15 @@
 import { redirect } from 'next/navigation'
 
 import { AdminApiError, patchAdminChat } from '@/lib/admin-api'
-import { getAdminSessionToken } from '@/lib/admin-session'
-import type {
-  AdminChatPatch,
-  AdminChatUpdateResult,
-} from '@/lib/admin-types'
+import { getSessionToken } from '@/lib/admin-session'
+import type { AdminChatPatch, AdminChatUpdateResult } from '@/lib/admin-types'
 
 export async function updateChatConfiguration(
   input: AdminChatPatch,
 ): Promise<AdminChatUpdateResult> {
-  const token = await getAdminSessionToken()
+  const token = await getSessionToken()
   if (!token) {
-    redirect('/admin/sign-in?error=session_expired')
+    redirect('/sign-in?error=session_expired&backUrl=%2Fadmin')
   }
 
   try {
@@ -26,10 +23,17 @@ export async function updateChatConfiguration(
     return { ok: true, configuration }
   } catch (error) {
     if (error instanceof AdminApiError) {
-      if (error.status === 401 || error.status === 403) {
-        redirect('/admin/sign-in?error=session_expired')
+      if (error.status === 401) {
+        redirect('/sign-in?error=session_expired&backUrl=%2Fadmin')
       }
-      return { ok: false, error: error.message }
+      if (error.status === 403) {
+        redirect('/')
+      }
+      return {
+        ok: false,
+        error: error.message,
+        conflict: error.status === 409,
+      }
     }
     return { ok: false, error: 'Could not update this chat. Try again.' }
   }

--- a/src/app/admin/admin-dashboard.tsx
+++ b/src/app/admin/admin-dashboard.tsx
@@ -112,7 +112,9 @@ export function AdminDashboard({
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const searchTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const submittedSearch = useRef(initialData.query.q)
   const [, startNavigation] = useTransition()
+  const [searchQuery, setSearchQuery] = useState(initialData.query.q)
   const [localConfigurations, setLocalConfigurations] = useState<
     Record<string, ChatConfiguration>
   >({})
@@ -127,6 +129,13 @@ export function AdminDashboard({
     },
     [],
   )
+
+  useEffect(() => {
+    if (initialData.query.q !== submittedSearch.current) {
+      submittedSearch.current = initialData.query.q
+      setSearchQuery(initialData.query.q)
+    }
+  }, [initialData.query.q])
 
   const chats = useMemo(
     () =>
@@ -167,7 +176,9 @@ export function AdminDashboard({
   function scheduleSearch(value: string) {
     if (searchTimer.current) clearTimeout(searchTimer.current)
     searchTimer.current = setTimeout(() => {
-      navigate({ q: value.trim() || undefined, page: undefined })
+      const query = value.trim()
+      submittedSearch.current = query
+      navigate({ q: query || undefined, page: undefined })
     }, 300)
   }
 
@@ -289,11 +300,13 @@ export function AdminDashboard({
                   <path d="m21 21-4.35-4.35m2.35-5.65a8 8 0 1 1-16 0 8 8 0 0 1 16 0Z" />
                 </svg>
                 <input
-                  defaultValue={query.q}
-                  key={query.q}
                   type="search"
                   placeholder="Search name, @username or ID"
-                  onChange={(event) => scheduleSearch(event.target.value)}
+                  value={searchQuery}
+                  onChange={(event) => {
+                    setSearchQuery(event.target.value)
+                    scheduleSearch(event.target.value)
+                  }}
                 />
               </label>
               <label className={styles.sortSelect}>

--- a/src/app/admin/admin-dashboard.tsx
+++ b/src/app/admin/admin-dashboard.tsx
@@ -1,19 +1,18 @@
 'use client'
 
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
-import { useDeferredValue, useMemo, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react'
 
 import type {
   AdminChatPatch,
+  AdminChatSortKey,
   AdminChatsResponse,
   AdminChatUpdateResult,
   ChatConfiguration,
+  SortDirection,
 } from '@/lib/admin-types'
 import styles from './admin.module.css'
-
-type SortKey = 'lastActivityAt' | 'name' | 'allowUpdatedAt' | 'toggledAt'
-type SortDirection = 'asc' | 'desc'
 
 interface AdminDashboardProps {
   initialData: AdminChatsResponse
@@ -84,24 +83,50 @@ function TelegramMark() {
   )
 }
 
+function SortButton({
+  activeDirection,
+  children,
+  onClick,
+}: {
+  activeDirection?: SortDirection
+  children: React.ReactNode
+  onClick: () => void
+}) {
+  return (
+    <button className={styles.sortButton} type="button" onClick={onClick}>
+      {children}
+      {activeDirection ? (
+        <span aria-label={`${activeDirection}ending`}>
+          {activeDirection === 'asc' ? '↑' : '↓'}
+        </span>
+      ) : null}
+    </button>
+  )
+}
+
 export function AdminDashboard({
   initialData,
   updateChat,
 }: AdminDashboardProps) {
   const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const searchTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const [, startNavigation] = useTransition()
   const [localConfigurations, setLocalConfigurations] = useState<
     Record<string, ChatConfiguration>
   >({})
-  const [query, setQuery] = useState('')
-  const [sortKey, setSortKey] = useState<SortKey>('lastActivityAt')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
-  const [pendingChats, setPendingChats] = useState<Set<string>>(
-    () => new Set(),
-  )
+  const [pendingChats, setPendingChats] = useState<Set<string>>(() => new Set())
   const [notice, setNotice] = useState<
     { kind: 'error' | 'success'; text: string } | undefined
   >()
-  const deferredQuery = useDeferredValue(query.trim().toLocaleLowerCase())
+
+  useEffect(
+    () => () => {
+      if (searchTimer.current) clearTimeout(searchTimer.current)
+    },
+    [],
+  )
 
   const chats = useMemo(
     () =>
@@ -114,52 +139,37 @@ export function AdminDashboard({
     [initialData.chats, localConfigurations],
   )
 
-  const counts = useMemo(
-    () => ({
-      total: chats.length,
-      allowed: chats.filter((chat) => chat.aiAllowed).length,
-      enabled: chats.filter(
-        (chat) => chat.aiAllowed && chat.agenticEnabled,
-      ).length,
-    }),
-    [chats],
-  )
-
-  const visibleChats = useMemo(() => {
-    const filtered = deferredQuery
-      ? chats.filter((chat) =>
-          [
-            chat.name,
-            chat.username,
-            chat.username ? `@${chat.username}` : undefined,
-            chat.chatId,
-          ]
-            .filter(Boolean)
-            .some((value) =>
-              String(value).toLocaleLowerCase().includes(deferredQuery),
-            ),
-        )
-      : chats
-
-    return [...filtered].sort((left, right) => {
-      let comparison: number
-      if (sortKey === 'name') {
-        comparison = left.name.localeCompare(right.name, undefined, {
-          numeric: true,
-          sensitivity: 'base',
-        })
-      } else {
-        comparison = (left[sortKey] ?? 0) - (right[sortKey] ?? 0)
-      }
-      return sortDirection === 'asc' ? comparison : -comparison
-    })
-  }, [chats, deferredQuery, sortDirection, sortKey])
-
   const adminName =
     initialData.admin.name ||
     (initialData.admin.username
       ? `@${initialData.admin.username}`
       : `Telegram ${initialData.admin.id}`)
+
+  function navigate(updates: Record<string, string | undefined>) {
+    const next = new URLSearchParams(searchParams.toString())
+    for (const [key, value] of Object.entries(updates)) {
+      if (value) next.set(key, value)
+      else next.delete(key)
+    }
+    startNavigation(() => {
+      router.replace(next.size ? `${pathname}?${next}` : pathname)
+    })
+  }
+
+  function sortBy(sort: AdminChatSortKey) {
+    const direction =
+      initialData.query.sort === sort && initialData.query.direction === 'asc'
+        ? 'desc'
+        : 'asc'
+    navigate({ sort, direction, page: undefined })
+  }
+
+  function scheduleSearch(value: string) {
+    if (searchTimer.current) clearTimeout(searchTimer.current)
+    searchTimer.current = setTimeout(() => {
+      navigate({ q: value.trim() || undefined, page: undefined })
+    }, 300)
+  }
 
   async function saveChat(input: AdminChatPatch, chatName: string) {
     setPendingChats((current) => new Set(current).add(input.chatId))
@@ -168,7 +178,7 @@ export function AdminDashboard({
       const result = await updateChat(input)
       if (!result.ok) {
         setNotice({ kind: 'error', text: result.error })
-        router.refresh()
+        if (result.conflict) router.refresh()
         return
       }
 
@@ -177,6 +187,7 @@ export function AdminDashboard({
         [input.chatId]: result.configuration,
       }))
       setNotice({ kind: 'success', text: `${chatName} updated.` })
+      router.refresh()
     } catch {
       setNotice({
         kind: 'error',
@@ -191,11 +202,20 @@ export function AdminDashboard({
     }
   }
 
+  const { pagination, query, summary } = initialData
+  const firstVisible = pagination.total
+    ? (pagination.page - 1) * pagination.pageSize + 1
+    : 0
+  const lastVisible = Math.min(
+    pagination.page * pagination.pageSize,
+    pagination.total,
+  )
+
   return (
     <main className={styles.dashboard}>
       <header className={styles.topBar}>
         <div className={styles.topBarInner}>
-          <div className={styles.brand}>
+          <Link className={styles.brand} href="/">
             <span className={styles.brandIcon}>
               <TelegramMark />
             </span>
@@ -203,18 +223,14 @@ export function AdminDashboard({
               <strong>Control room</strong>
               <small>Telegram agent</small>
             </span>
-          </div>
+          </Link>
           <div className={styles.ownerMenu}>
             <span className={styles.ownerAvatar}>{initials(adminName)}</span>
             <span className={styles.ownerIdentity}>
               <strong>{adminName}</strong>
               <small>Owner · {initialData.admin.id}</small>
             </span>
-            <Link
-              className={styles.logoutLink}
-              href="/admin/logout"
-              prefetch={false}
-            >
+            <Link className={styles.logoutLink} href="/logout" prefetch={false}>
               Sign out
             </Link>
           </div>
@@ -238,17 +254,17 @@ export function AdminDashboard({
         <dl className={styles.metrics}>
           <div>
             <dt>Known chats</dt>
-            <dd>{counts.total}</dd>
+            <dd>{summary.total}</dd>
             <span>Seen by the bot</span>
           </div>
           <div>
             <dt>AI allowed</dt>
-            <dd>{counts.allowed}</dd>
+            <dd>{summary.allowed}</dd>
             <span>Owner allowlist</span>
           </div>
           <div>
             <dt>Agent active</dt>
-            <dd>{counts.enabled}</dd>
+            <dd>{summary.enabled}</dd>
             <span>Allowed and switched on</span>
           </div>
         </dl>
@@ -258,9 +274,10 @@ export function AdminDashboard({
             <div>
               <h2 id="chat-directory">Chat directory</h2>
               <p>
-                {visibleChats.length === chats.length
-                  ? `${chats.length} chats`
-                  : `${visibleChats.length} of ${chats.length} chats`}
+                Showing {firstVisible}–{lastVisible} of {pagination.total}
+                {pagination.total !== summary.total
+                  ? ` filtered · ${summary.total} known`
+                  : ' chats'}
               </p>
             </div>
             <div className={styles.controls}>
@@ -272,37 +289,27 @@ export function AdminDashboard({
                   <path d="m21 21-4.35-4.35m2.35-5.65a8 8 0 1 1-16 0 8 8 0 0 1 16 0Z" />
                 </svg>
                 <input
+                  defaultValue={query.q}
+                  key={query.q}
                   type="search"
                   placeholder="Search name, @username or ID"
-                  value={query}
-                  onChange={(event) => setQuery(event.target.value)}
+                  onChange={(event) => scheduleSearch(event.target.value)}
                 />
               </label>
               <label className={styles.sortSelect}>
-                <span className={styles.visuallyHidden}>Sort chats</span>
+                <span className={styles.visuallyHidden}>Filter AI access</span>
                 <select
-                  value={sortKey}
-                  onChange={(event) => setSortKey(event.target.value as SortKey)}
+                  aria-label="Filter AI access"
+                  value={query.aiAccess}
+                  onChange={(event) =>
+                    navigate({ aiAccess: event.target.value, page: undefined })
+                  }
                 >
-                  <option value="lastActivityAt">Last active</option>
-                  <option value="name">Name</option>
-                  <option value="allowUpdatedAt">Allow changed</option>
-                  <option value="toggledAt">Agent changed</option>
+                  <option value="all">All AI access</option>
+                  <option value="allowed">AI allowed</option>
+                  <option value="blocked">AI blocked</option>
                 </select>
               </label>
-              <button
-                className={styles.directionButton}
-                type="button"
-                aria-label={`Sort ${sortDirection === 'asc' ? 'descending' : 'ascending'}`}
-                title={`Currently ${sortDirection === 'asc' ? 'ascending' : 'descending'}`}
-                onClick={() =>
-                  setSortDirection((current) =>
-                    current === 'asc' ? 'desc' : 'asc',
-                  )
-                }
-              >
-                {sortDirection === 'asc' ? '↑' : '↓'}
-              </button>
             </div>
           </div>
 
@@ -313,15 +320,43 @@ export function AdminDashboard({
             {notice?.text ?? '\u00a0'}
           </div>
 
-          <div className={styles.tableHeader} aria-hidden="true">
-            <span>Chat</span>
-            <span>Last active</span>
-            <span>AI access</span>
-            <span>Agent</span>
+          <div className={styles.tableHeader}>
+            <SortButton
+              activeDirection={
+                query.sort === 'name' ? query.direction : undefined
+              }
+              onClick={() => sortBy('name')}
+            >
+              Chat
+            </SortButton>
+            <SortButton
+              activeDirection={
+                query.sort === 'lastActivityAt' ? query.direction : undefined
+              }
+              onClick={() => sortBy('lastActivityAt')}
+            >
+              Last active
+            </SortButton>
+            <SortButton
+              activeDirection={
+                query.sort === 'aiAccess' ? query.direction : undefined
+              }
+              onClick={() => sortBy('aiAccess')}
+            >
+              AI access
+            </SortButton>
+            <SortButton
+              activeDirection={
+                query.sort === 'agent' ? query.direction : undefined
+              }
+              onClick={() => sortBy('agent')}
+            >
+              Agent
+            </SortButton>
           </div>
 
           <div className={styles.chatList}>
-            {visibleChats.map((chat) => {
+            {chats.map((chat) => {
               const pending = pendingChats.has(chat.chatId)
               return (
                 <article className={styles.chatRow} key={chat.chatId}>
@@ -343,7 +378,9 @@ export function AdminDashboard({
                     <span className={styles.mobileLabel}>Last active</span>
                     <strong>{formatDate(chat.lastActivityAt)}</strong>
                     <small>
-                      {chat.configured ? `Config v${chat.version}` : 'No config yet'}
+                      {chat.configured
+                        ? `Config v${chat.version}`
+                        : 'No config yet'}
                     </small>
                   </div>
 
@@ -392,13 +429,51 @@ export function AdminDashboard({
             })}
           </div>
 
-          {visibleChats.length === 0 ? (
+          {chats.length === 0 ? (
             <div className={styles.emptyState}>
               <span aria-hidden="true">⌕</span>
               <strong>No matching chats</strong>
               <p>Try a name, username, or the numeric Telegram chat ID.</p>
             </div>
           ) : null}
+
+          <footer className={styles.pagination}>
+            <label>
+              <span>Rows</span>
+              <select
+                aria-label="Rows per page"
+                value={pagination.pageSize}
+                onChange={(event) =>
+                  navigate({ pageSize: event.target.value, page: undefined })
+                }
+              >
+                {[10, 20, 50, 100].map((size) => (
+                  <option key={size} value={size}>
+                    {size}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <span>
+              Page {pagination.page} of {pagination.totalPages}
+            </span>
+            <div>
+              <button
+                disabled={pagination.page <= 1}
+                type="button"
+                onClick={() => navigate({ page: String(pagination.page - 1) })}
+              >
+                Previous
+              </button>
+              <button
+                disabled={pagination.page >= pagination.totalPages}
+                type="button"
+                onClick={() => navigate({ page: String(pagination.page + 1) })}
+              >
+                Next
+              </button>
+            </div>
+          </footer>
         </section>
       </div>
     </main>

--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -306,7 +306,8 @@
 }
 
 .sortSelect select,
-.directionButton {
+.pagination select,
+.pagination button {
   height: 38px;
   border: 1px solid #dfe4ea;
   border-radius: 9px;
@@ -320,14 +321,10 @@
   padding: 0 30px 0 11px;
 }
 
-.directionButton {
-  width: 38px;
-  cursor: pointer;
-  font-size: 17px;
-}
-
 .sortSelect select:focus-visible,
-.directionButton:focus-visible,
+.pagination select:focus-visible,
+.pagination button:focus-visible,
+.sortButton:focus-visible,
 .switch:focus-visible,
 .logoutLink:focus-visible,
 .telegramButton:focus-visible,
@@ -372,6 +369,27 @@
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+}
+
+.sortButton {
+  min-width: 0;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+}
+
+.sortButton span {
+  color: var(--blue-dark);
+  font-size: 13px;
 }
 
 .chatRow {
@@ -530,6 +548,40 @@
   margin: 6px 0 0;
   color: var(--muted);
   font-size: 12px;
+}
+
+.pagination {
+  min-height: 58px;
+  padding: 10px 22px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 18px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  background: #fafbfc;
+  font-size: 11px;
+}
+
+.pagination label,
+.pagination > div {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.pagination select {
+  padding: 0 22px 0 8px;
+}
+
+.pagination button {
+  padding: 0 12px;
+  cursor: pointer;
+}
+
+.pagination button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
 }
 
 .mobileLabel,
@@ -764,6 +816,17 @@
 
   .controls {
     justify-content: stretch;
+  }
+
+  .pagination {
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+
+  .pagination > span {
+    flex: 1;
+    align-self: center;
+    text-align: center;
   }
 
   .searchBox {

--- a/src/app/admin/callback/route.ts
+++ b/src/app/admin/callback/route.ts
@@ -1,14 +1,16 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
-import { AdminApiError, createAdminSession } from '@/lib/admin-api'
+import { createSession } from '@/lib/admin-api'
 import { getTelegramOidcConfiguration } from '@/lib/admin-config'
 import {
-  ADMIN_SESSION_COOKIE,
+  getSafeBackUrl,
+  OIDC_BACK_URL_COOKIE,
   OIDC_NONCE_COOKIE,
   OIDC_STATE_COOKIE,
   OIDC_VERIFIER_COOKIE,
-  adminCookieOptions,
+  SESSION_COOKIE,
+  sessionCookieOptions,
 } from '@/lib/admin-session'
 
 export const runtime = 'nodejs'
@@ -22,14 +24,19 @@ function clearOidcCookies(response: NextResponse): void {
     OIDC_STATE_COOKIE,
     OIDC_NONCE_COOKIE,
     OIDC_VERIFIER_COOKIE,
+    OIDC_BACK_URL_COOKIE,
   ]) {
-    response.cookies.set(name, '', { ...adminCookieOptions, maxAge: 0 })
+    response.cookies.set(name, '', { ...sessionCookieOptions, maxAge: 0 })
   }
 }
 
 function errorRedirect(request: NextRequest, code: string): NextResponse {
-  const url = new URL('/admin/sign-in', request.url)
+  const url = new URL('/sign-in', request.url)
   url.searchParams.set('error', code)
+  const backUrl = getSafeBackUrl(
+    request.cookies.get(OIDC_BACK_URL_COOKIE)?.value,
+  )
+  if (backUrl !== '/') url.searchParams.set('backUrl', backUrl)
   const response = NextResponse.redirect(url)
   clearOidcCookies(response)
   return response
@@ -69,25 +76,24 @@ export async function GET(request: NextRequest) {
     })
 
     const tokens = (await tokenResponse.json().catch(() => ({}))) as
-      | TelegramTokenResponse
-      | undefined
+      TelegramTokenResponse | undefined
     if (!tokenResponse.ok || typeof tokens?.id_token !== 'string') {
       return errorRedirect(request, 'token_exchange_failed')
     }
 
-    const session = await createAdminSession(tokens.id_token, nonce)
-    const response = NextResponse.redirect(new URL('/admin', request.url))
-    response.cookies.set(ADMIN_SESSION_COOKIE, session.token, {
-      ...adminCookieOptions,
+    const session = await createSession(tokens.id_token, nonce)
+    const backUrl = getSafeBackUrl(
+      request.cookies.get(OIDC_BACK_URL_COOKIE)?.value,
+    )
+    const response = NextResponse.redirect(new URL(backUrl, request.url))
+    response.cookies.set(SESSION_COOKIE, session.token, {
+      ...sessionCookieOptions,
       maxAge: session.expiresIn,
     })
     clearOidcCookies(response)
     response.headers.set('Cache-Control', 'no-store')
     return response
-  } catch (error) {
-    if (error instanceof AdminApiError && error.status === 403) {
-      return errorRedirect(request, 'not_allowed')
-    }
+  } catch {
     return errorRedirect(request, 'login_failed')
   }
 }

--- a/src/app/admin/login/route.ts
+++ b/src/app/admin/login/route.ts
@@ -1,47 +1,8 @@
-import { createHash, randomBytes } from 'node:crypto'
-
+import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
-import { getTelegramOidcConfiguration } from '@/lib/admin-config'
-import {
-  OIDC_NONCE_COOKIE,
-  OIDC_STATE_COOKIE,
-  OIDC_VERIFIER_COOKIE,
-  adminCookieOptions,
-} from '@/lib/admin-session'
-
-export const runtime = 'nodejs'
-
-function randomBase64Url(bytes = 32): string {
-  return randomBytes(bytes).toString('base64url')
-}
-
-export function GET() {
-  const { clientId, redirectUri } = getTelegramOidcConfiguration()
-  const state = randomBase64Url()
-  const nonce = randomBase64Url()
-  const verifier = randomBase64Url(48)
-  const challenge = createHash('sha256')
-    .update(verifier)
-    .digest('base64url')
-
-  const authorizationUrl = new URL('https://oauth.telegram.org/auth')
-  authorizationUrl.search = new URLSearchParams({
-    client_id: clientId,
-    redirect_uri: redirectUri,
-    response_type: 'code',
-    scope: 'openid profile',
-    state,
-    nonce,
-    code_challenge: challenge,
-    code_challenge_method: 'S256',
-  }).toString()
-
-  const response = NextResponse.redirect(authorizationUrl)
-  const options = { ...adminCookieOptions, maxAge: 10 * 60 }
-  response.cookies.set(OIDC_STATE_COOKIE, state, options)
-  response.cookies.set(OIDC_NONCE_COOKIE, nonce, options)
-  response.cookies.set(OIDC_VERIFIER_COOKIE, verifier, options)
-  response.headers.set('Cache-Control', 'no-store')
-  return response
+export function GET(request: NextRequest) {
+  const url = new URL('/login', request.url)
+  url.searchParams.set('backUrl', '/admin')
+  return NextResponse.redirect(url)
 }

--- a/src/app/admin/logout/route.ts
+++ b/src/app/admin/logout/route.ts
@@ -1,16 +1,6 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
-import {
-  ADMIN_SESSION_COOKIE,
-  adminCookieOptions,
-} from '@/lib/admin-session'
-
 export function GET(request: NextRequest) {
-  const response = NextResponse.redirect(new URL('/admin/sign-in', request.url))
-  response.cookies.set(ADMIN_SESSION_COOKIE, '', {
-    ...adminCookieOptions,
-    maxAge: 0,
-  })
-  return response
+  return NextResponse.redirect(new URL('/logout', request.url))
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,32 +1,65 @@
 import { redirect } from 'next/navigation'
 
 import { AdminApiError, getAdminChats } from '@/lib/admin-api'
-import { getAdminSessionToken } from '@/lib/admin-session'
-import type { AdminChatsResponse } from '@/lib/admin-types'
+import { getSessionToken } from '@/lib/admin-session'
+import type {
+  AdminChatListOptions,
+  AdminChatSortKey,
+  AdminChatsResponse,
+  AiAccessFilter,
+  SortDirection,
+} from '@/lib/admin-types'
 import { updateChatConfiguration } from './actions'
 import { AdminDashboard } from './admin-dashboard'
 
-export default async function AdminPage() {
-  const token = await getAdminSessionToken()
-  if (!token) redirect('/admin/sign-in')
+interface AdminPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function first(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function parseOptions(
+  values: Record<string, string | string[] | undefined>,
+): AdminChatListOptions {
+  const aiAccess = first(values.aiAccess)
+  const sort = first(values.sort)
+  const direction = first(values.direction)
+  return {
+    page: Number(first(values.page)) || undefined,
+    pageSize: Number(first(values.pageSize)) || undefined,
+    q: first(values.q),
+    aiAccess: (['all', 'allowed', 'blocked'].includes(aiAccess ?? '')
+      ? aiAccess
+      : undefined) as AiAccessFilter | undefined,
+    sort: (['name', 'lastActivityAt', 'aiAccess', 'agent'].includes(sort ?? '')
+      ? sort
+      : undefined) as AdminChatSortKey | undefined,
+    direction: (['asc', 'desc'].includes(direction ?? '')
+      ? direction
+      : undefined) as SortDirection | undefined,
+  }
+}
+
+export default async function AdminPage({ searchParams }: AdminPageProps) {
+  const token = await getSessionToken()
+  if (!token) redirect('/sign-in?backUrl=%2Fadmin')
 
   let data: AdminChatsResponse
   try {
-    data = await getAdminChats(token)
+    data = await getAdminChats(token, parseOptions(await searchParams))
   } catch (error) {
-    if (
-      error instanceof AdminApiError &&
-      (error.status === 401 || error.status === 403)
-    ) {
-      redirect('/admin/sign-in?error=session_expired')
+    if (error instanceof AdminApiError && error.status === 401) {
+      redirect('/sign-in?error=session_expired&backUrl=%2Fadmin')
+    }
+    if (error instanceof AdminApiError && error.status === 403) {
+      redirect('/')
     }
     throw error
   }
 
   return (
-    <AdminDashboard
-      initialData={data}
-      updateChat={updateChatConfiguration}
-    />
+    <AdminDashboard initialData={data} updateChat={updateChatConfiguration} />
   )
 }

--- a/src/app/admin/sign-in/page.tsx
+++ b/src/app/admin/sign-in/page.tsx
@@ -1,72 +1,13 @@
-import Link from 'next/link'
-
-import styles from '../admin.module.css'
-
-const errorMessages: Record<string, string> = {
-  invalid_state: 'That login request expired. Please start again.',
-  login_failed: 'Telegram login could not be completed.',
-  not_allowed: 'This Telegram account is not the configured bot owner.',
-  session_expired: 'Your admin session expired. Sign in again.',
-  telegram_rejected: 'Telegram login was cancelled.',
-  token_exchange_failed: 'Telegram did not accept the login code.',
-}
+import { redirect } from 'next/navigation'
 
 interface SignInPageProps {
   searchParams: Promise<{ error?: string | string[] }>
 }
 
-function TelegramLogo() {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M21.8 3.6 18.7 19c-.2 1.1-.9 1.4-1.8.9l-4.7-3.5-2.3 2.2c-.3.3-.5.5-1 .5l.3-4.8 8.8-8c.4-.3-.1-.5-.6-.2L6.5 13 1.8 11.5c-1-.3-1-1 .2-1.5L20.4 3c.9-.3 1.6.2 1.4.6Z" />
-    </svg>
-  )
-}
-
 export default async function SignInPage({ searchParams }: SignInPageProps) {
   const error = (await searchParams).error
   const errorCode = Array.isArray(error) ? error[0] : error
-  const errorMessage = errorCode ? errorMessages[errorCode] : undefined
-
-  return (
-    <main className={styles.signInPage}>
-      <section className={styles.signInCard}>
-        <div className={styles.signInBrand} aria-hidden="true">
-          <span className={styles.brandPulse} />
-          <span className={styles.brandMark}>A</span>
-        </div>
-        <p className={styles.eyebrow}>Private workspace</p>
-        <h1>Bot control room</h1>
-        <p className={styles.signInLead}>
-          Inspect chats and control where the AI agent is allowed to run.
-          Access is limited to the Telegram account configured as the bot owner.
-        </p>
-
-        {errorMessage ? (
-          <p className={styles.signInError} role="alert">
-            {errorMessage}
-          </p>
-        ) : null}
-
-        <Link
-          className={styles.telegramButton}
-          href="/admin/login"
-          prefetch={false}
-        >
-          <span className={styles.telegramIcon}>
-            <TelegramLogo />
-          </span>
-          Continue with Telegram
-        </Link>
-
-        <div className={styles.securityNote}>
-          <span className={styles.securityDot} />
-          <span>
-            Telegram verifies your identity. Cloud credentials never reach the
-            browser.
-          </span>
-        </div>
-      </section>
-    </main>
-  )
+  const params = new URLSearchParams({ backUrl: '/admin' })
+  if (errorCode) params.set('error', errorCode)
+  redirect(`/sign-in?${params}`)
 }

--- a/src/app/chat/[id]/chat-dashboard.tsx
+++ b/src/app/chat/[id]/chat-dashboard.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import styled from 'styled-components'
+
+import { Card } from '@/components/card.component'
+import { ChatInfo } from '@/components/chat-info.component'
+import { HistoricalStatistics } from '@/components/chat/historical-statistics.component'
+import { LastDayStatistics } from '@/components/chat/last-day-statistics.component'
+import { Spinner } from '@/components/spinner.component'
+import { useChatData } from '@/hooks/use-chat-data.hook'
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin: auto;
+`
+const Container = styled.div`
+  width: 1200px;
+  max-width: 100vw;
+`
+const LoadingWrapper = styled(Wrapper)`
+  min-height: 100vh;
+`
+const GraphCard = styled(Card)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 1200px;
+  margin: 20px;
+  padding: 15px 0;
+  @media (max-width: 800px) {
+    margin: 10px;
+    max-width: calc(100vw - 20px);
+  }
+`
+const LoadingCard = styled(GraphCard)`
+  height: 506px;
+`
+
+export function ChatDashboard({
+  chatId,
+  accessToken,
+}: {
+  chatId: string
+  accessToken: string
+}) {
+  const { loading, data, error } = useChatData(chatId, accessToken)
+  const { chatInfo, usersData, historicalData } = data
+
+  if (error) return <LoadingWrapper>{error}</LoadingWrapper>
+
+  return (
+    <>
+      {!loading && <ChatInfo data={chatInfo} />}
+      <Wrapper>
+        {loading ? (
+          <Container>
+            {[0, 1].map((index) => (
+              <LoadingCard key={index}>
+                <Spinner />
+              </LoadingCard>
+            ))}
+          </Container>
+        ) : (
+          <Container>
+            <LastDayStatistics usersData={usersData} />
+            <HistoricalStatistics historicalData={historicalData || []} />
+          </Container>
+        )}
+      </Wrapper>
+    </>
+  )
+}

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -1,85 +1,87 @@
-'use client'
+import Link from 'next/link'
 
-import { use } from 'react'
-import styled from 'styled-components'
+import { AdminApiError, getChatAccess } from '@/lib/admin-api'
+import { getSessionToken } from '@/lib/admin-session'
+import styles from '../../home.module.css'
+import { ChatDashboard } from './chat-dashboard'
 
-import { Card } from '@/components/card.component'
-import { ChatInfo } from '@/components/chat-info.component'
-import { HistoricalStatistics } from '@/components/chat/historical-statistics.component'
-import { LastDayStatistics } from '@/components/chat/last-day-statistics.component'
-import { Spinner } from '@/components/spinner.component'
-import { useChatData } from '@/hooks/use-chat-data.hook'
-
-const Wrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  margin: auto;
-`
-const Container = styled.div`
-  width: 1200px;
-  max-width: 100vw;
-`
-const LoadingWrapper = styled(Wrapper)`
-  min-height: 100vh;
-`
-const GraphCard = styled(Card)`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  max-width: 1200px;
-  margin: 20px;
-  padding: 15px 0;
-  @media (max-width: 800px) {
-    margin: 10px;
-    max-width: calc(100vw - 20px);
-  }
-`
-const LoadingCard = styled(GraphCard)`
-  height: 506px;
-`
-
-type ChatPageProps = {
+interface ChatPageProps {
   params: Promise<{ id: string }>
   searchParams: Promise<{ access?: string | string[] }>
 }
 
-const ChatPage = ({ params, searchParams }: ChatPageProps) => {
-  const { id } = use(params)
-  const { access } = use(searchParams)
-  const accessToken = Array.isArray(access) ? access[0] : access
-  const { loading, data, error } = useChatData(id, accessToken)
-  const { chatInfo, usersData, historicalData } = data
-
-  if (error) {
-    return <LoadingWrapper>{error}</LoadingWrapper>
-  }
-
+export function ChatAccessMessage({
+  chatId,
+  denied = false,
+}: {
+  chatId: string
+  denied?: boolean
+}) {
+  const backUrl = `/chat/${encodeURIComponent(chatId)}`
+  const loginHref = `/login?${new URLSearchParams({ backUrl })}`
   return (
-    <>
-      {!loading && <ChatInfo data={chatInfo} />}
-      <Wrapper>
-        {loading && (
-          <Container>
-            {[0, 1].map((i) => (
-              <LoadingCard key={i}>
-                <Spinner />
-              </LoadingCard>
-            ))}
-          </Container>
+    <main className={styles.page}>
+      <section className={styles.hero}>
+        <span className={styles.mark}>T</span>
+        <p className={styles.eyebrow}>Private chat statistics</p>
+        <h1>
+          {denied ? 'This chat is not in your list.' : 'Sign in to continue.'}
+        </h1>
+        <p className={styles.lead}>
+          {denied
+            ? 'The bot has not observed activity from your Telegram account in this chat.'
+            : 'Telegram login lets us match this page to chats where the bot has observed your account.'}
+        </p>
+        {denied ? (
+          <Link className={styles.primaryAction} href="/">
+            View your chats
+          </Link>
+        ) : (
+          <Link
+            className={styles.primaryAction}
+            href={loginHref}
+            prefetch={false}
+          >
+            Continue with Telegram
+          </Link>
         )}
-        {!loading && (
-          <Container>
-            <LastDayStatistics usersData={usersData} />
-            <HistoricalStatistics historicalData={historicalData || []} />
-          </Container>
-        )}
-      </Wrapper>
-    </>
+      </section>
+    </main>
   )
 }
 
-export default ChatPage
+export default async function ChatPage({
+  params,
+  searchParams,
+}: ChatPageProps) {
+  const { id } = await params
+  const access = (await searchParams).access
+  const legacyAccessToken = Array.isArray(access) ? access[0] : access
+  if (legacyAccessToken) {
+    return <ChatDashboard chatId={id} accessToken={legacyAccessToken} />
+  }
+
+  const sessionToken = await getSessionToken()
+  if (!sessionToken) return <ChatAccessMessage chatId={id} />
+
+  let accessToken: string | undefined
+  let accessDenied = false
+  try {
+    accessToken = (await getChatAccess(sessionToken, id)).accessToken
+  } catch (error) {
+    if (error instanceof AdminApiError && error.status === 401) {
+      accessToken = undefined
+    } else if (error instanceof AdminApiError && error.status === 403) {
+      accessDenied = true
+    } else {
+      throw error
+    }
+  }
+
+  if (accessDenied) return <ChatAccessMessage chatId={id} denied />
+  return accessToken ? (
+    <ChatDashboard chatId={id} accessToken={accessToken} />
+  ) : (
+    <ChatAccessMessage chatId={id} />
+  )
+}

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -1,0 +1,217 @@
+.page {
+  --ink: #17202a;
+  --muted: #697586;
+  --line: #e3e8ee;
+  --blue: #229ed9;
+  min-height: 100vh;
+  padding: 32px clamp(20px, 5vw, 72px) 72px;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 88% 0%, rgb(34 158 217 / 12%), transparent 32rem),
+    #f5f7fa;
+}
+
+.header {
+  width: min(1180px, 100%);
+  min-height: 52px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.wordmark {
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.nav a {
+  color: #167fab;
+  font-weight: 600;
+}
+
+.hero,
+.workspace {
+  width: min(960px, 100%);
+  margin: 0 auto;
+}
+
+.hero {
+  min-height: calc(100vh - 104px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.workspace {
+  padding-top: 80px;
+}
+
+.mark {
+  width: 48px;
+  height: 48px;
+  margin-bottom: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  color: white;
+  background: #111821;
+  box-shadow: 8px 8px 0 rgb(34 158 217 / 20%);
+  font-weight: 700;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #147cac;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.hero h1,
+.workspace h1 {
+  max-width: 760px;
+  margin: 0;
+  font-size: clamp(36px, 7vw, 68px);
+  line-height: 1.02;
+  letter-spacing: -0.055em;
+}
+
+.workspace h1 {
+  font-size: clamp(34px, 5vw, 52px);
+}
+
+.lead {
+  max-width: 650px;
+  margin: 20px 0 28px;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.lead code {
+  color: #273546;
+  font-weight: 700;
+}
+
+.warning {
+  margin: -8px 0 20px;
+  padding: 10px 12px;
+  border: 1px solid #f1cdd1;
+  border-radius: 9px;
+  color: #a52e3b;
+  background: #fff7f8;
+  font-size: 12px;
+}
+
+.primaryAction {
+  min-height: 48px;
+  padding: 0 22px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 10px;
+  color: white;
+  background: var(--blue);
+  box-shadow: 0 8px 22px rgb(34 158 217 / 22%);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.chatGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.chatCard {
+  min-height: 170px;
+  padding: 22px;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: 0 10px 32px rgb(24 39 58 / 5%);
+  transition: 160ms ease;
+}
+
+.chatCard:hover {
+  border-color: #acd9eb;
+  transform: translateY(-2px);
+}
+
+.chatCard strong {
+  margin: 16px 0 6px;
+  font-size: 18px;
+}
+
+.chatCard > span:not(.chatType) {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.chatCard small {
+  margin-top: auto;
+  color: #8b96a5;
+  font-size: 10px;
+}
+
+.chatType {
+  padding: 5px 8px;
+  border-radius: 999px;
+  color: #147cac;
+  background: #eef8fc;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.emptyState {
+  padding: 38px;
+  border: 1px dashed #ccd5df;
+  border-radius: 14px;
+  color: var(--muted);
+  background: rgb(255 255 255 / 55%);
+}
+
+.emptyState strong {
+  color: var(--ink);
+}
+
+.emptyState p {
+  margin: 7px 0 0;
+  font-size: 13px;
+}
+
+@media (max-width: 700px) {
+  .nav > span {
+    display: none;
+  }
+
+  .workspace {
+    padding-top: 54px;
+  }
+
+  .chatGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chatCard {
+    transition: none;
+  }
+}

--- a/src/app/login/route.ts
+++ b/src/app/login/route.ts
@@ -1,0 +1,50 @@
+import { createHash, randomBytes } from 'node:crypto'
+
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+import { getTelegramOidcConfiguration } from '@/lib/admin-config'
+import {
+  getSafeBackUrl,
+  OIDC_BACK_URL_COOKIE,
+  OIDC_NONCE_COOKIE,
+  OIDC_STATE_COOKIE,
+  OIDC_VERIFIER_COOKIE,
+  sessionCookieOptions,
+} from '@/lib/admin-session'
+
+export const runtime = 'nodejs'
+
+function randomBase64Url(bytes = 32): string {
+  return randomBytes(bytes).toString('base64url')
+}
+
+export function GET(request: NextRequest) {
+  const { clientId, redirectUri } = getTelegramOidcConfiguration()
+  const state = randomBase64Url()
+  const nonce = randomBase64Url()
+  const verifier = randomBase64Url(48)
+  const challenge = createHash('sha256').update(verifier).digest('base64url')
+  const backUrl = getSafeBackUrl(request.nextUrl.searchParams.get('backUrl'))
+
+  const authorizationUrl = new URL('https://oauth.telegram.org/auth')
+  authorizationUrl.search = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: 'openid profile',
+    state,
+    nonce,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  }).toString()
+
+  const response = NextResponse.redirect(authorizationUrl)
+  const options = { ...sessionCookieOptions, maxAge: 10 * 60 }
+  response.cookies.set(OIDC_STATE_COOKIE, state, options)
+  response.cookies.set(OIDC_NONCE_COOKIE, nonce, options)
+  response.cookies.set(OIDC_VERIFIER_COOKIE, verifier, options)
+  response.cookies.set(OIDC_BACK_URL_COOKIE, backUrl, options)
+  response.headers.set('Cache-Control', 'no-store')
+  return response
+}

--- a/src/app/logout/route.ts
+++ b/src/app/logout/route.ts
@@ -1,21 +1,12 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
-import {
-  LEGACY_ADMIN_SESSION_COOKIE,
-  SESSION_COOKIE,
-  sessionCookieOptions,
-} from '@/lib/admin-session'
+import { SESSION_COOKIE, sessionCookieOptions } from '@/lib/admin-session'
 
 export function GET(request: NextRequest) {
   const response = NextResponse.redirect(new URL('/', request.url))
   response.cookies.set(SESSION_COOKIE, '', {
     ...sessionCookieOptions,
-    maxAge: 0,
-  })
-  response.cookies.set(LEGACY_ADMIN_SESSION_COOKIE, '', {
-    ...sessionCookieOptions,
-    path: '/admin',
     maxAge: 0,
   })
   return response

--- a/src/app/logout/route.ts
+++ b/src/app/logout/route.ts
@@ -1,0 +1,22 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+import {
+  LEGACY_ADMIN_SESSION_COOKIE,
+  SESSION_COOKIE,
+  sessionCookieOptions,
+} from '@/lib/admin-session'
+
+export function GET(request: NextRequest) {
+  const response = NextResponse.redirect(new URL('/', request.url))
+  response.cookies.set(SESSION_COOKIE, '', {
+    ...sessionCookieOptions,
+    maxAge: 0,
+  })
+  response.cookies.set(LEGACY_ADMIN_SESSION_COOKIE, '', {
+    ...sessionCookieOptions,
+    path: '/admin',
+    maxAge: 0,
+  })
+  return response
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,41 +1,123 @@
-import styled from 'styled-components'
+import Link from 'next/link'
 
-const Wrapper = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  text-align: center;
-`
-const Content = styled.div`
-  width: 500px;
-  max-width: 100vw;
-  padding: 20px;
-`
-const Command = styled.span`
-  display: inline-block;
-  font-weight: bold;
-`
+import { AdminApiError, getUserChats } from '@/lib/admin-api'
+import { getSessionToken } from '@/lib/admin-session'
+import type { UserChatsResponse } from '@/lib/admin-types'
+import styles from './home.module.css'
 
-const IndexPage = () => {
+const dateFormatter = new Intl.DateTimeFormat('en-GB', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+  timeZone: 'Europe/Stockholm',
+})
+
+function displayName(data: UserChatsResponse): string {
   return (
-    <Wrapper>
-      <Content>
-        <h4 className="text-md font-bold my-4">
-          Hi, I&apos;m a Telegram chat bot.
-        </h4>
-        <p className="my-2">
-          Add the bot to your chat and invoke the <Command>/s</Command> command
-          in Telegram to get a private statistics link.
-        </p>
-        <p className="my-2">
-          Links expire automatically and only grant access to the chat they
-          were created for.
-        </p>
-      </Content>
-    </Wrapper>
+    data.user.name ||
+    (data.user.username ? `@${data.user.username}` : `Telegram ${data.user.id}`)
   )
 }
 
-export default IndexPage
+export function SignedOutHome({ expired = false }: { expired?: boolean }) {
+  return (
+    <main className={styles.page}>
+      <section className={styles.hero}>
+        <span className={styles.mark}>T</span>
+        <p className={styles.eyebrow}>Telegram bot statistics</p>
+        <h1>Your chats, without public links.</h1>
+        <p className={styles.lead}>
+          Sign in with Telegram to see chats where the bot has already observed
+          your account. Existing private links from <code>/s</code> keep
+          working.
+        </p>
+        {expired ? (
+          <p className={styles.warning} role="alert">
+            Your session expired. Sign in again.
+          </p>
+        ) : null}
+        <Link
+          className={styles.primaryAction}
+          href="/login?backUrl=%2F"
+          prefetch={false}
+        >
+          Continue with Telegram
+        </Link>
+      </section>
+    </main>
+  )
+}
+
+export function UserHome({ data }: { data: UserChatsResponse }) {
+  const name = displayName(data)
+  return (
+    <main className={styles.page}>
+      <header className={styles.header}>
+        <Link href="/" className={styles.wordmark}>
+          Telegram stats
+        </Link>
+        <nav className={styles.nav} aria-label="Account">
+          <span>{name}</span>
+          {data.user.isAdmin ? <Link href="/admin">Control room</Link> : null}
+          <Link href="/logout" prefetch={false}>
+            Sign out
+          </Link>
+        </nav>
+      </header>
+
+      <section className={styles.workspace}>
+        <p className={styles.eyebrow}>Signed in as {name}</p>
+        <h1>Your chats</h1>
+        <p className={styles.lead}>
+          These are chats where this bot has recorded activity from your
+          Telegram account.
+        </p>
+
+        {data.chats.length ? (
+          <div className={styles.chatGrid}>
+            {data.chats.map((chat) => (
+              <Link
+                className={styles.chatCard}
+                href={`/chat/${encodeURIComponent(chat.chatId)}`}
+                key={chat.chatId}
+              >
+                <span className={styles.chatType}>{chat.type ?? 'chat'}</span>
+                <strong>{chat.name}</strong>
+                <span>
+                  {chat.username ? `@${chat.username} · ` : ''}
+                  {chat.messageCount.toLocaleString()} messages from you
+                </span>
+                <small>
+                  {chat.lastActivityAt
+                    ? `Last seen ${dateFormatter.format(chat.lastActivityAt)}`
+                    : 'No activity timestamp'}
+                </small>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <div className={styles.emptyState}>
+            <strong>No chats found yet</strong>
+            <p>
+              Send a message in a chat that contains the bot, then refresh this
+              page.
+            </p>
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}
+
+export default async function IndexPage() {
+  const token = await getSessionToken()
+  if (!token) return <SignedOutHome />
+
+  let data: UserChatsResponse | undefined
+  try {
+    data = await getUserChats(token)
+  } catch (error) {
+    if (!(error instanceof AdminApiError) || error.status !== 401) throw error
+  }
+
+  return data ? <UserHome data={data} /> : <SignedOutHome expired />
+}

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -1,0 +1,77 @@
+import Link from 'next/link'
+
+import { getSafeBackUrl } from '@/lib/admin-session'
+import styles from '../admin/admin.module.css'
+
+const errorMessages: Record<string, string> = {
+  invalid_state: 'That login request expired. Please start again.',
+  login_failed: 'Telegram login could not be completed.',
+  session_expired: 'Your session expired. Sign in again.',
+  telegram_rejected: 'Telegram login was cancelled.',
+  token_exchange_failed: 'Telegram did not accept the login code.',
+}
+
+interface SignInPageProps {
+  searchParams: Promise<{
+    backUrl?: string | string[]
+    error?: string | string[]
+  }>
+}
+
+function TelegramLogo() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M21.8 3.6 18.7 19c-.2 1.1-.9 1.4-1.8.9l-4.7-3.5-2.3 2.2c-.3.3-.5.5-1 .5l.3-4.8 8.8-8c.4-.3-.1-.5-.6-.2L6.5 13 1.8 11.5c-1-.3-1-1 .2-1.5L20.4 3c.9-.3 1.6.2 1.4.6Z" />
+    </svg>
+  )
+}
+
+export default async function SignInPage({ searchParams }: SignInPageProps) {
+  const values = await searchParams
+  const error = Array.isArray(values.error) ? values.error[0] : values.error
+  const errorMessage = error ? errorMessages[error] : undefined
+  const backUrl = getSafeBackUrl(values.backUrl)
+  const loginHref = `/login?${new URLSearchParams({ backUrl })}`
+
+  return (
+    <main className={styles.signInPage}>
+      <section className={styles.signInCard}>
+        <div className={styles.signInBrand} aria-hidden="true">
+          <span className={styles.brandPulse} />
+          <span className={styles.brandMark}>T</span>
+        </div>
+        <p className={styles.eyebrow}>Private statistics</p>
+        <h1>Continue with Telegram</h1>
+        <p className={styles.signInLead}>
+          Sign in to see chats where the bot has observed your Telegram account.
+          Bot-owner controls remain available only to the owner.
+        </p>
+
+        {errorMessage ? (
+          <p className={styles.signInError} role="alert">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <Link
+          className={styles.telegramButton}
+          href={loginHref}
+          prefetch={false}
+        >
+          <span className={styles.telegramIcon}>
+            <TelegramLogo />
+          </span>
+          Continue with Telegram
+        </Link>
+
+        <div className={styles.securityNote}>
+          <span className={styles.securityDot} />
+          <span>
+            Telegram verifies your identity. Cloud credentials never reach the
+            browser.
+          </span>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/lib/admin-api.ts
+++ b/src/lib/admin-api.ts
@@ -2,9 +2,12 @@ import 'server-only'
 
 import { getAdminApiBaseUrl } from './admin-config'
 import type {
+  AdminChatListOptions,
   AdminChatsResponse,
-  AdminSessionResponse,
+  ChatAccessResponse,
   ChatConfiguration,
+  SessionResponse,
+  UserChatsResponse,
 } from './admin-types'
 
 export class AdminApiError extends Error {
@@ -21,10 +24,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-async function requestAdminApi<T>(
-  path: string,
-  init: RequestInit,
-): Promise<T> {
+async function requestAdminApi<T>(path: string, init: RequestInit): Promise<T> {
   const response = await fetch(`${getAdminApiBaseUrl()}${path}`, {
     ...init,
     cache: 'no-store',
@@ -46,18 +46,47 @@ async function requestAdminApi<T>(
   return value as T
 }
 
-export function createAdminSession(
+export function createSession(
   idToken: string,
   nonce: string,
-): Promise<AdminSessionResponse> {
-  return requestAdminApi('/admin/session', {
+): Promise<SessionResponse> {
+  return requestAdminApi('/session', {
     method: 'POST',
     body: JSON.stringify({ idToken, nonce }),
   })
 }
 
-export function getAdminChats(token: string): Promise<AdminChatsResponse> {
-  return requestAdminApi('/admin/chats', {
+export function getUserChats(token: string): Promise<UserChatsResponse> {
+  return requestAdminApi('/chats', {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+export function getChatAccess(
+  token: string,
+  chatId: string,
+): Promise<ChatAccessResponse> {
+  return requestAdminApi(`/chats/${encodeURIComponent(chatId)}/access`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+export function getAdminChats(
+  token: string,
+  options: AdminChatListOptions = {},
+): Promise<AdminChatsResponse> {
+  const search = new URLSearchParams()
+  if (options.page) search.set('page', String(options.page))
+  if (options.pageSize) search.set('pageSize', String(options.pageSize))
+  if (options.q) search.set('q', options.q)
+  if (options.aiAccess) search.set('aiAccess', options.aiAccess)
+  if (options.sort) search.set('sort', options.sort)
+  if (options.direction) search.set('direction', options.direction)
+  const query = search.size ? `?${search}` : ''
+
+  return requestAdminApi(`/admin/chats${query}`, {
     method: 'GET',
     headers: { Authorization: `Bearer ${token}` },
   })

--- a/src/lib/admin-session.ts
+++ b/src/lib/admin-session.ts
@@ -3,7 +3,6 @@ import 'server-only'
 import { cookies } from 'next/headers'
 
 export const SESSION_COOKIE = 'telegram_session'
-export const LEGACY_ADMIN_SESSION_COOKIE = 'telegram_admin_session'
 export const OIDC_STATE_COOKIE = 'telegram_admin_oidc_state'
 export const OIDC_VERIFIER_COOKIE = 'telegram_admin_oidc_verifier'
 export const OIDC_NONCE_COOKIE = 'telegram_admin_oidc_nonce'
@@ -44,8 +43,5 @@ export function getSafeBackUrl(
 
 export async function getSessionToken(): Promise<string | undefined> {
   const store = await cookies()
-  return (
-    store.get(SESSION_COOKIE)?.value ??
-    store.get(LEGACY_ADMIN_SESSION_COOKIE)?.value
-  )
+  return store.get(SESSION_COOKIE)?.value
 }

--- a/src/lib/admin-session.ts
+++ b/src/lib/admin-session.ts
@@ -2,18 +2,50 @@ import 'server-only'
 
 import { cookies } from 'next/headers'
 
-export const ADMIN_SESSION_COOKIE = 'telegram_admin_session'
+export const SESSION_COOKIE = 'telegram_session'
+export const LEGACY_ADMIN_SESSION_COOKIE = 'telegram_admin_session'
 export const OIDC_STATE_COOKIE = 'telegram_admin_oidc_state'
 export const OIDC_VERIFIER_COOKIE = 'telegram_admin_oidc_verifier'
 export const OIDC_NONCE_COOKIE = 'telegram_admin_oidc_nonce'
+export const OIDC_BACK_URL_COOKIE = 'telegram_oidc_back_url'
 
-export const adminCookieOptions = {
+export const sessionCookieOptions = {
   httpOnly: true,
   sameSite: 'lax' as const,
   secure: process.env.NODE_ENV === 'production',
-  path: '/admin',
+  path: '/',
 }
 
-export async function getAdminSessionToken(): Promise<string | undefined> {
-  return (await cookies()).get(ADMIN_SESSION_COOKIE)?.value
+export function getSafeBackUrl(
+  value: string | string[] | null | undefined,
+  fallback = '/',
+): string {
+  const candidate = Array.isArray(value) ? value[0] : value
+  if (
+    !candidate ||
+    candidate.length > 2048 ||
+    !candidate.startsWith('/') ||
+    candidate.startsWith('//') ||
+    candidate.includes('\\') ||
+    /[\r\n]/.test(candidate)
+  ) {
+    return fallback
+  }
+
+  try {
+    const parsed = new URL(candidate, 'https://telegram-bot.local')
+    return parsed.origin === 'https://telegram-bot.local'
+      ? `${parsed.pathname}${parsed.search}${parsed.hash}`
+      : fallback
+  } catch {
+    return fallback
+  }
+}
+
+export async function getSessionToken(): Promise<string | undefined> {
+  const store = await cookies()
+  return (
+    store.get(SESSION_COOKIE)?.value ??
+    store.get(LEGACY_ADMIN_SESSION_COOKIE)?.value
+  )
 }

--- a/src/lib/admin-types.ts
+++ b/src/lib/admin-types.ts
@@ -1,8 +1,12 @@
-export interface AdminIdentity {
+export interface SessionIdentity {
   id: string
   name?: string
   username?: string
   picture?: string
+}
+
+export interface SessionUser extends SessionIdentity {
+  isAdmin: boolean
 }
 
 export interface ChatConfiguration {
@@ -25,14 +29,59 @@ export interface AdminChatRecord extends ChatConfiguration {
 }
 
 export interface AdminChatsResponse {
-  admin: AdminIdentity
+  admin: SessionIdentity
   chats: AdminChatRecord[]
+  pagination: {
+    page: number
+    pageSize: number
+    total: number
+    totalPages: number
+  }
+  summary: {
+    total: number
+    allowed: number
+    enabled: number
+  }
+  query: AdminChatListOptions
 }
 
-export interface AdminSessionResponse {
+export type AdminChatSortKey = 'name' | 'lastActivityAt' | 'aiAccess' | 'agent'
+export type SortDirection = 'asc' | 'desc'
+export type AiAccessFilter = 'all' | 'allowed' | 'blocked'
+
+export interface AdminChatListOptions {
+  page?: number
+  pageSize?: number
+  q?: string
+  aiAccess?: AiAccessFilter
+  sort?: AdminChatSortKey
+  direction?: SortDirection
+}
+
+export interface SessionResponse {
   token: string
   expiresIn: number
-  admin: AdminIdentity
+  user: SessionUser
+}
+
+export interface UserChatRecord {
+  chatId: string
+  name: string
+  username?: string
+  type?: string
+  lastActivityAt?: number
+  messageCount: number
+}
+
+export interface UserChatsResponse {
+  user: SessionUser
+  chats: UserChatRecord[]
+}
+
+export interface ChatAccessResponse {
+  chatId: string
+  accessToken: string
+  expiresIn: number
 }
 
 export interface AdminChatPatch {
@@ -44,4 +93,4 @@ export interface AdminChatPatch {
 
 export type AdminChatUpdateResult =
   | { ok: true; configuration: ChatConfiguration }
-  | { ok: false; error: string }
+  | { ok: false; error: string; conflict?: boolean }


### PR DESCRIPTION
## What changed

- replace the admin-only cookie with one site-wide Telegram session and remove the legacy cookie fallback
- keep the registered Telegram OIDC callback, PKCE, state, and nonce flow; add a validated same-origin `backUrl`
- turn the home page into a signed-in “my chats” workspace
- let direct `/chat/{id}` links obtain a short-lived scoped token after login, while preserving legacy `?access=` links from `/s`
- make admin search controlled, debounced, and API-backed; add AI-access filtering, clickable column sorting, page-size controls, and pagination
- refresh optimistic rows only when needed and preserve version conflict handling
- add tests for callback return URLs, open-redirect rejection, chat access states, user chat rendering, search focus/state preservation, URL filters, sorting, and pagination

## Dependency / deployment order

Depends on [telegram-bot-app#63](https://github.com/EugeneDraitsev/telegram-bot-app/pull/63).

Merge and deploy the backend PR first. This UI calls the new `POST /session`, `GET /chats`, and `GET /chats/{chatId}/access` endpoints.

No auth framework was added: Telegram already supplies standard OIDC Authorization Code + PKCE, and the Lambda still needs its own signed bearer session and chat-scoped token. Adding another framework would duplicate that session layer.

## Access semantics

“My chats” lists chats where the bot has already observed activity from the signed-in Telegram user. It is historical bot-observed access, not a claim that Telegram guarantees a current membership lookup for every chat.

## Validation

- `bun run lint`
- `bun run tsc`
- `bun test` — 27 passing
- `bun run build` — Next.js production build completed
- Chromium smoke: `/` and `/chat/-1001306676509` returned 200, rendered meaningful content, had zero console errors and no Next error overlay; the chat login link preserved the exact back URL