### PR TITLE
Add a messages-over-time card to the chat page

### DIFF
--- a/src/__tests__/message-volume.test.tsx
+++ b/src/__tests__/message-volume.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { ThemeProvider } from '../contexts'
+import type { MessageCounts } from '@/types'
+
+const { MessageVolume } = await import(
+  '../components/chat/message-volume.component'
+)
+
+const series = (length: number, count: number, step: number) =>
+  Array.from({ length }, (_, index) => ({
+    t: Date.UTC(2026, 7, 20) - (length - index) * step,
+    count,
+  }))
+
+const HOUR = 60 * 60 * 1000
+const DAY = 24 * HOUR
+
+const messageCounts: MessageCounts = {
+  day: series(24, 5, HOUR),
+  week: series(7, 100, DAY),
+  month: series(30, 10, DAY),
+  year: series(12, 1000, 30 * DAY),
+}
+
+const renderVolume = (counts?: MessageCounts) =>
+  render(
+    <ThemeProvider>
+      <MessageVolume messageCounts={counts} />
+    </ThemeProvider>,
+  )
+
+describe('message volume card', () => {
+  test('opens on the day range and totals its buckets', () => {
+    renderVolume(messageCounts)
+
+    expect(screen.getByText(/Last 24 hours, by hour/)).toBeInTheDocument()
+    expect(screen.getByText(/120 messages/)).toBeInTheDocument()
+  })
+
+  test.each([
+    ['Week', 'Last 7 days, by day', '700 messages'],
+    ['Month', 'Last 30 days, by day', '300 messages'],
+    ['Year', 'Last 12 months, by month', '12,000 messages'],
+  ])('switches to %s', (tab, caption, total) => {
+    renderVolume(messageCounts)
+
+    fireEvent.click(screen.getByRole('tab', { name: tab }))
+
+    expect(screen.getByText(new RegExp(caption))).toBeInTheDocument()
+    expect(screen.getByText(new RegExp(total))).toBeInTheDocument()
+  })
+
+  test('renders an empty card instead of failing without counts', () => {
+    renderVolume(undefined)
+
+    expect(screen.getByText(/0 messages/)).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Day' })).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/message-volume.test.tsx
+++ b/src/__tests__/message-volume.test.tsx
@@ -7,9 +7,10 @@ const { MessageVolume } = await import(
   '../components/chat/message-volume.component'
 )
 
+// The last bucket is the current, partial one, exactly as the backend sends it.
 const series = (length: number, count: number, step: number) =>
   Array.from({ length }, (_, index) => ({
-    t: Date.UTC(2026, 7, 20) - (length - index) * step,
+    t: Date.UTC(2026, 7, 20) - (length - 1 - index) * step,
     count,
   }))
 
@@ -51,10 +52,29 @@ describe('message volume card', () => {
     expect(screen.getByText(new RegExp(total))).toBeInTheDocument()
   })
 
-  test('renders an empty card instead of failing without counts', () => {
+  test('ends on the current bucket rather than the previous one', () => {
+    const last = messageCounts.year[messageCounts.year.length - 1]
+
+    expect(last.t).toBe(Date.UTC(2026, 7, 20))
+  })
+
+  test('says the counts are unavailable rather than claiming zero', () => {
     renderVolume(undefined)
 
-    expect(screen.getByText(/0 messages/)).toBeInTheDocument()
+    expect(screen.getByText(/Data unavailable/)).toBeInTheDocument()
+    expect(screen.queryByText(/0 messages/)).not.toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Day' })).toBeInTheDocument()
+  })
+
+  test('still reports a genuinely quiet chat as zero', () => {
+    renderVolume({
+      day: series(24, 0, HOUR),
+      week: series(7, 0, DAY),
+      month: series(30, 0, DAY),
+      year: series(12, 0, 30 * DAY),
+    })
+
+    expect(screen.getByText(/0 messages/)).toBeInTheDocument()
+    expect(screen.queryByText(/Data unavailable/)).not.toBeInTheDocument()
   })
 })

--- a/src/app/chat/[id]/chat-dashboard.tsx
+++ b/src/app/chat/[id]/chat-dashboard.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import { ChatInfo } from '@/components/chat-info.component'
 import { HistoricalStatistics } from '@/components/chat/historical-statistics.component'
 import { LastDayStatistics } from '@/components/chat/last-day-statistics.component'
+import { MessageVolume } from '@/components/chat/message-volume.component'
 import { StatisticsSkeleton } from '@/components/chat/statistics-skeleton.component'
 import { useChatData } from '@/hooks/use-chat-data.hook'
 
@@ -35,7 +36,7 @@ export function ChatDashboard({
   memberCount?: number
 }) {
   const { loading, data, error } = useChatData(chatId, accessToken)
-  const { chatInfo, usersData, historicalData } = data
+  const { chatInfo, usersData, historicalData, messageCounts } = data
 
   if (error) return <ErrorWrapper>{error}</ErrorWrapper>
 
@@ -53,10 +54,12 @@ export function ChatDashboard({
           <Container role="status" aria-label="Loading chat statistics">
             <StatisticsSkeleton />
             <StatisticsSkeleton />
+            <StatisticsSkeleton />
           </Container>
         ) : (
           <Container>
             <LastDayStatistics usersData={usersData} />
+            <MessageVolume messageCounts={messageCounts} />
             <HistoricalStatistics historicalData={historicalData || []} />
           </Container>
         )}

--- a/src/components/chat/message-volume.component.tsx
+++ b/src/components/chat/message-volume.component.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
+
+import { Tabs } from '@/components/tabs.component'
+import type { MessageCountRange, MessageCounts } from '@/types'
+import { GraphCard, Header, SubTitle, Title } from './chat.styles'
+import { ChartPlaceholder } from './statistics-skeleton.component'
+
+const MessageVolumeBars = dynamic(
+  () =>
+    import('../graphs/message-volume-bars.component').then(
+      (module) => module.MessageVolumeBars,
+    ),
+  { ssr: false, loading: ChartPlaceholder },
+)
+
+const RANGES: MessageCountRange[] = ['day', 'week', 'month', 'year']
+const TAB_LABELS = ['Day', 'Week', 'Month', 'Year']
+const RANGE_CAPTIONS: Record<MessageCountRange, string> = {
+  day: 'Last 24 hours, by hour',
+  week: 'Last 7 days, by day',
+  month: 'Last 30 days, by day',
+  year: 'Last 12 months, by month',
+}
+
+interface MessageVolumeProps {
+  messageCounts?: MessageCounts
+}
+
+export const MessageVolume = ({ messageCounts }: MessageVolumeProps) => {
+  const [tab, setTab] = useState(0)
+  const range = RANGES[tab]
+  const points = messageCounts?.[range] ?? []
+  const total = points.reduce((sum, point) => sum + point.count, 0)
+
+  return (
+    <GraphCard>
+      <Header>
+        <Title>
+          Messages over time
+          <SubTitle>
+            {RANGE_CAPTIONS[range]} · {total.toLocaleString()} messages
+          </SubTitle>
+        </Title>
+        <Tabs
+          tabs={TAB_LABELS}
+          selectedIndex={tab}
+          onTabClick={(index) => setTab(index)}
+        />
+      </Header>
+      <MessageVolumeBars data={points} range={range} />
+    </GraphCard>
+  )
+}

--- a/src/components/chat/message-volume.component.tsx
+++ b/src/components/chat/message-volume.component.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic'
 import { useState } from 'react'
+import styled from 'styled-components'
 
 import { Tabs } from '@/components/tabs.component'
 import type { MessageCountRange, MessageCounts } from '@/types'
@@ -25,6 +26,19 @@ const RANGE_CAPTIONS: Record<MessageCountRange, string> = {
   year: 'Last 12 months, by month',
 }
 
+// Same footprint as the chart, so losing the counts does not resize the card.
+const Unavailable = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 400px;
+  padding: 0 20px;
+  color: #8791a0;
+  font-size: 13px;
+  text-align: center;
+`
+
 interface MessageVolumeProps {
   messageCounts?: MessageCounts
 }
@@ -32,8 +46,12 @@ interface MessageVolumeProps {
 export const MessageVolume = ({ messageCounts }: MessageVolumeProps) => {
   const [tab, setTab] = useState(0)
   const range = RANGES[tab]
-  const points = messageCounts?.[range] ?? []
-  const total = points.reduce((sum, point) => sum + point.count, 0)
+  // Absent counts mean the backend could not read them, which is not the same
+  // as a quiet chat: a real zero arrives as buckets that are all zero. Showing
+  // "0 messages" for a failed read would be a lie, and a visible one next to a
+  // card that did load.
+  const points = messageCounts?.[range]
+  const total = points?.reduce((sum, point) => sum + point.count, 0) ?? 0
 
   return (
     <GraphCard>
@@ -41,7 +59,8 @@ export const MessageVolume = ({ messageCounts }: MessageVolumeProps) => {
         <Title>
           Messages over time
           <SubTitle>
-            {RANGE_CAPTIONS[range]} · {total.toLocaleString()} messages
+            {RANGE_CAPTIONS[range]}
+            {points ? ` · ${total.toLocaleString()} messages` : ''}
           </SubTitle>
         </Title>
         <Tabs
@@ -50,7 +69,14 @@ export const MessageVolume = ({ messageCounts }: MessageVolumeProps) => {
           onTabClick={(index) => setTab(index)}
         />
       </Header>
-      <MessageVolumeBars data={points} range={range} />
+      {points ? (
+        <MessageVolumeBars data={points} range={range} />
+      ) : (
+        <Unavailable role="status">
+          Data unavailable. Message counts could not be read for this chat —
+          the rest of this page is unaffected.
+        </Unavailable>
+      )}
     </GraphCard>
   )
 }

--- a/src/components/graphs/message-volume-bars.component.tsx
+++ b/src/components/graphs/message-volume-bars.component.tsx
@@ -12,11 +12,8 @@ import {
 } from 'recharts'
 import { tint } from 'polished'
 
+import { STATISTICS_TIME_ZONE } from '@/constants'
 import type { MessageCountPoint, MessageCountRange } from '@/types'
-
-// Buckets are UTC instants; formatting them in the app's display zone keeps the
-// label pointing at the same moment without shifting a bucket into another day.
-const ZONE = 'Europe/Stockholm'
 
 const AXIS_FORMATS: Record<MessageCountRange, Intl.DateTimeFormatOptions> = {
   day: { hour: '2-digit', minute: '2-digit' },
@@ -33,7 +30,7 @@ const TOOLTIP_FORMATS: Record<MessageCountRange, Intl.DateTimeFormatOptions> = {
 }
 
 const format = (value: number, options: Intl.DateTimeFormatOptions) =>
-  new Intl.DateTimeFormat('en-GB', { ...options, timeZone: ZONE }).format(value)
+  new Intl.DateTimeFormat('en-GB', { ...options, timeZone: STATISTICS_TIME_ZONE }).format(value)
 
 interface MessageVolumeBarsProps {
   data: MessageCountPoint[]

--- a/src/components/graphs/message-volume-bars.component.tsx
+++ b/src/components/graphs/message-volume-bars.component.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { tint } from 'polished'
+
+import type { MessageCountPoint, MessageCountRange } from '@/types'
+
+// Buckets are UTC instants; formatting them in the app's display zone keeps the
+// label pointing at the same moment without shifting a bucket into another day.
+const ZONE = 'Europe/Stockholm'
+
+const AXIS_FORMATS: Record<MessageCountRange, Intl.DateTimeFormatOptions> = {
+  day: { hour: '2-digit', minute: '2-digit' },
+  week: { weekday: 'short' },
+  month: { day: 'numeric', month: 'short' },
+  year: { month: 'short' },
+}
+
+const TOOLTIP_FORMATS: Record<MessageCountRange, Intl.DateTimeFormatOptions> = {
+  day: { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' },
+  week: { weekday: 'long', day: 'numeric', month: 'short' },
+  month: { day: 'numeric', month: 'short' },
+  year: { month: 'long', year: 'numeric' },
+}
+
+const format = (value: number, options: Intl.DateTimeFormatOptions) =>
+  new Intl.DateTimeFormat('en-GB', { ...options, timeZone: ZONE }).format(value)
+
+interface MessageVolumeBarsProps {
+  data: MessageCountPoint[]
+  range: MessageCountRange
+}
+
+export const MessageVolumeBars = ({ data, range }: MessageVolumeBarsProps) => (
+  <ResponsiveContainer height={400}>
+    <BarChart data={data} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+      <CartesianGrid stroke="#eef1f4" vertical={false} />
+      <Bar dataKey="count" minPointSize={1} radius={[2, 2, 0, 0]}>
+        {data.map((point, index) => (
+          <Cell key={point.t} fill={tint(index / (data.length * 1.3), '#4A90E2')} />
+        ))}
+      </Bar>
+      <XAxis
+        dataKey="t"
+        tick={{ fontSize: 11 }}
+        tickLine={false}
+        axisLine={{ stroke: '#d8dee5' }}
+        interval="preserveStartEnd"
+        minTickGap={12}
+        tickFormatter={(value: number) => format(value, AXIS_FORMATS[range])}
+      />
+      <YAxis
+        allowDecimals={false}
+        tick={{ fontSize: 11 }}
+        tickLine={false}
+        axisLine={false}
+        width={44}
+      />
+      <Tooltip
+        cursor={{ fill: 'rgba(74, 144, 226, 0.08)' }}
+        labelStyle={{ fontSize: 12, lineHeight: '12px', marginBottom: 8 }}
+        itemStyle={{ fontSize: 12, lineHeight: '12px' }}
+        wrapperStyle={{ opacity: 0.95 }}
+        labelFormatter={(label) =>
+          typeof label === 'number' ? format(label, TOOLTIP_FORMATS[range]) : ''
+        }
+        formatter={(value) => [
+          typeof value === 'number' ? value.toLocaleString() : value,
+          'Messages',
+        ]}
+      />
+    </BarChart>
+  </ResponsiveContainer>
+)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,3 +3,10 @@ export const CONFIG = {
     process.env.NEXT_PUBLIC_WEBSOCKET_URL ??
     'wss://6se5wu8bt9.execute-api.eu-central-1.amazonaws.com/prod',
 }
+
+/**
+ * Zone the statistics calendar is cut and labelled in. The backend cuts day and
+ * month buckets in this same zone (STATISTICS_TIME_ZONE in telegram-bot-app);
+ * changing one without the other shifts every bucket against its label.
+ */
+export const STATISTICS_TIME_ZONE = 'Europe/Stockholm'

--- a/src/hooks/use-chat-data.hook.ts
+++ b/src/hooks/use-chat-data.hook.ts
@@ -2,12 +2,18 @@ import { useEffect, useState } from 'react'
 
 import { safeParse } from '@/utils'
 import { CONFIG } from '@/constants'
-import type { Chat, DailyUserData, HistoricalData } from '@/types'
+import type {
+  Chat,
+  DailyUserData,
+  HistoricalData,
+  MessageCounts,
+} from '@/types'
 
 export type ChatData = {
   chatInfo?: Chat
   usersData: DailyUserData[]
   historicalData?: HistoricalData[]
+  messageCounts?: MessageCounts
 }
 
 type ChatDataMessage = Partial<ChatData> & { error?: unknown }
@@ -75,6 +81,7 @@ export const useChatData = (
       const historicalData = Array.isArray(message.historicalData)
         ? message.historicalData
         : undefined
+      const messageCounts = message.messageCounts
       if (!message.chatInfo && !usersData && !historicalData) {
         setError(
           `Seems like we don't have any events for this chat (${chatId}) for last 24h`,
@@ -87,6 +94,7 @@ export const useChatData = (
         chatInfo: message.chatInfo ?? current.chatInfo,
         usersData: usersData ?? current.usersData,
         historicalData: historicalData ?? current.historicalData,
+        messageCounts: messageCounts ?? current.messageCounts,
       }))
     }
     socket.onerror = () => {

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -36,3 +36,13 @@ export type HistoricalData = {
   msgCount: number
   username: string
 }
+
+export type MessageCountRange = 'day' | 'week' | 'month' | 'year'
+
+export type MessageCountPoint = {
+  /** Bucket start, epoch milliseconds UTC. */
+  t: number
+  count: number
+}
+
+export type MessageCounts = Record<MessageCountRange, MessageCountPoint[]>


### PR DESCRIPTION
## What changed

- third card on the chat page, between the last-24h breakdown and the historical table
- `Day / Week / Month / Year` tabs on the existing `Tabs` component
- new `MessageVolumeBars` chart, loaded with `next/dynamic` and the same 400px placeholder as the other two, so the card never collapses while its chunk loads
- `messageCounts` threaded through `useChatData` and the shared types

Each tab draws its own bucketing, exactly as the backend sends it:

| tab | buckets |
|---|---|
| Day | 24 hours, by hour |
| Week | 7 days, by day |
| Month | 30 days, by day |
| Year | 12 calendar months, by month |

Buckets are UTC instants formatted in the app's display zone, so a label points at the same moment as the rest of the page and no bucket slides into the neighbouring day.

## Dependency / deployment order

Depends on [telegram-bot-app#64](https://github.com/EugeneDraitsev/telegram-bot-app/pull/64). Merge and deploy the backend first — it adds `messageCounts` to the WebSocket stats payload. Without it the field is simply absent and the card renders with zeros instead of breaking.

## Verified locally

Ran the page against a stand-in stats socket:

- three cards, heights 506 / 506 / 881 — the new one matches its neighbours and the loading skeleton
- Day renders 24 bars, Year renders 12, and the caption totals follow the tab
- axes label correctly (`Aug … Jul` across the year, counts on Y)
- no horizontal overflow

## Validation

- `bun run lint`, `bun run tsc`
- `bun test` — 38 passing, including a new suite covering tab switching, per-range totals, and the no-data case
- `bun run build` — Next.js production build completed